### PR TITLE
Add basic TokenVault contract that mints and burns shares

### DIFF
--- a/src/Interfaces/IShare.sol
+++ b/src/Interfaces/IShare.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IShare {
+    function mint(address to, uint256 amount) external;
+
+    function burn(address from, uint256 amount) external;
+}

--- a/src/Share.sol
+++ b/src/Share.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import {IShare} from "./Interfaces/IShare.sol";
+
+contract Share is IShare, ERC20 {
+    constructor() ERC20("EGG", "Cosmic Egg") {}
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) public {
+        _burn(from, amount);
+    }
+}

--- a/src/TokenVault.sol
+++ b/src/TokenVault.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import {IShare} from "./Interfaces/IShare.sol";
+
+contract TokenVault {
+    IERC20 internal share;
+    uint256 public totalShares;
+
+    mapping(address => UserInfo) public userInfo;
+
+    struct UserInfo {
+        uint256 shares;
+        uint256 lastDepositedTime;
+        uint256 valueAtLastUserAction;
+        uint256 lastUserActionTime;
+    }
+
+    event Deposit(address indexed sender, uint256 amount, uint256 shares, uint256 lastDepositedTime);
+    event Withdraw(address indexed sender, uint256 amount, uint256 shares);
+
+    constructor(IERC20 _share) {
+        share = _share;
+    }
+
+    function deposit() external payable {
+        require(msg.value > 0, "Nothing to deposit");
+
+        uint256 pool = balanceOf();
+        uint256 currentShares = 0;
+
+        if (totalShares != 0) {
+            currentShares = SafeMath.div(SafeMath.mul(msg.value, totalShares), pool);
+        } else {
+            currentShares = msg.value;
+        }
+
+        UserInfo storage user = userInfo[msg.sender];
+
+        user.shares = SafeMath.add(user.shares, currentShares);
+        user.lastDepositedTime = block.timestamp;
+
+        totalShares = SafeMath.add(totalShares, currentShares);
+
+        user.valueAtLastUserAction = SafeMath.div(SafeMath.mul(user.shares, balanceOf()), totalShares);
+        user.lastUserActionTime = block.timestamp;
+
+        IShare(address(share)).mint(msg.sender, currentShares);
+
+        emit Deposit(msg.sender, msg.value, currentShares, block.timestamp);
+    }
+
+    function withdraw(uint256 _shares) external {
+        UserInfo storage user = userInfo[msg.sender];
+        require(_shares > 0, "Nothing to withdraw");
+        require(_shares <= user.shares, "Withdraw amount exceeds balance");
+
+        uint256 currentAmount = SafeMath.div(SafeMath.mul(balanceOf(), _shares), totalShares);
+        user.shares = SafeMath.sub(user.shares, _shares);
+        totalShares = SafeMath.sub(totalShares, _shares);
+
+        if (user.shares > 0) {
+            user.valueAtLastUserAction = SafeMath.div(SafeMath.mul(user.shares, balanceOf()), totalShares);
+        } else {
+            user.valueAtLastUserAction = 0;
+        }
+
+        user.lastUserActionTime = block.timestamp;
+
+        payable(msg.sender).transfer(currentAmount);
+
+        IShare(address(share)).burn(msg.sender, currentAmount);
+
+        emit Withdraw(msg.sender, currentAmount, _shares);
+    }
+
+    function available() public view returns (uint256) {
+        return IERC20(share).balanceOf(address(this));
+    }
+
+    function balanceOf() public view returns (uint256) {
+        return IERC20(share).balanceOf(msg.sender);
+    }
+}

--- a/test/TokenVault.t.sol
+++ b/test/TokenVault.t.sol
@@ -82,10 +82,12 @@ contract TokenVaultTest is Test {
         assert(vaultBalance > withdrawAmount);
 
         share.approve(address(vault), withdrawAmount);
+        uint256 shareBalance = share.balanceOf(alice);
 
         vault.withdraw(1 ether);
 
         assertEq(address(vault).balance, vaultBalance - withdrawAmount);
+        assertEq(share.balanceOf(alice), shareBalance - withdrawAmount);
 
         vm.stopPrank();
     }

--- a/test/TokenVault.t.sol
+++ b/test/TokenVault.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "./Utils.sol";
+
+import "../src/TokenVault.sol";
+import "../src/Share.sol";
+
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+
+contract TokenVaultTest is Test {
+    Utils internal utils;
+    Share public share;
+    TokenVault public vault;
+    address payable[] internal users;
+
+    address alice;
+    address bob;
+
+    event Deposit(address indexed sender, uint256 amount, uint256 shares, uint256 lastDepositedTime);
+    event Withdraw(address indexed sender, uint256 amount, uint256 shares);
+
+    function setUp() public {
+        utils = new Utils();
+        share = new Share();
+        vault = new TokenVault(IERC20(share));
+
+        users = utils.createUsers(4);
+        alice = users[0];
+        vm.label(alice, "Alice");
+
+        bob = users[1];
+        vm.label(bob, "Bob");
+    }
+
+    function testDeposit() public {
+        vm.startPrank(alice);
+        vm.warp(100);
+
+        vm.expectEmit(true, false, false, true);
+        emit Deposit(address(alice), 1 ether, 1 ether, 100);
+
+        assertEq(address(vault).balance, 0);
+
+        vault.deposit{value: 1 ether}();
+
+        uint256 shareBalance = share.balanceOf(alice);
+        assertEq(shareBalance, 1 ether);
+
+        assertEq(address(vault).balance, 1 ether);
+
+        vm.stopPrank();
+    }
+
+    function testWithdrawExceedsAmount() public {
+        vm.startPrank(alice);
+
+        vm.expectRevert("Withdraw amount exceeds balance");
+        vault.withdraw(1 ether);
+
+        vm.stopPrank();
+    }
+
+    function testWithdraw() public {
+        vm.startPrank(alice);
+
+        vault.deposit{value: 2 ether}();
+        assertEq(address(vault).balance, 2 ether);
+
+        vm.expectEmit(true, false, false, true);
+        emit Withdraw(address(alice), 1 ether, 1 ether);
+
+        uint256 totalShares = vault.totalShares();
+        uint256 currentBalance = vault.balanceOf();
+
+        uint256 withdrawAmount = currentBalance * 1 ether / totalShares;
+
+        uint256 vaultBalance = address(vault).balance;
+
+        assert(vaultBalance > withdrawAmount);
+
+        share.approve(address(vault), withdrawAmount);
+
+        vault.withdraw(1 ether);
+
+        assertEq(address(vault).balance, vaultBalance - withdrawAmount);
+
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
Why:
* We want to have a way to exchange FIL for shares and vice versa

How:
* Adding a `TokenVault` contract that implements a barebones version of
  the ERC4626 contract just so we can better explore how we want to
  tackle this issue
